### PR TITLE
MS-31 feat(registration-form): implement opportunity for user to select billing and shipping addresses

### DIFF
--- a/src/components/elements.ts
+++ b/src/components/elements.ts
@@ -1,11 +1,11 @@
-export function createInput(id: string, type: string, className: string[], placeholder?: string, pattern?: string, title?: string) {
+export function createInput(id: string, type: string, className: string[], placeholder?: string, pattern?: RegExp, title?: string) {
   const input = document.createElement("input");
   input.type = type;
   input.id = id;
   input.name = id;
   input.classList.add(...className);
   if (placeholder) input.placeholder = placeholder;
-  if (pattern) input.pattern = `${pattern}`;
+  if (pattern) input.pattern = `${pattern}`.replaceAll("/", "");
   if (title) input.title = title;
   input.setAttribute("required", "true");
   input.setAttribute("autocomplete", "true");

--- a/src/index.css
+++ b/src/index.css
@@ -80,6 +80,10 @@ h1 {
   z-index: 1;
 }
 
+h5 {
+  margin-top: 10px;
+}
+
 .registration-form__heading,
 .login-form__heading {
   text-align: center;
@@ -95,38 +99,30 @@ h1 {
   margin-bottom: 20px;
 }
 
-input {
+input,
+select,
+select option {
   width: 100%;
   border: none;
   margin-top: 20px;
   padding: 10px 5%;
-  background-color: var(--light-grey);
+  background-color: var(--main-light);
 }
 
-select,
-select option {
-  margin-top: 20px;
-  width: 100%;
-  padding: 10px 5%;
-  background-color: var(--light-grey);
-}
-
-input:valid,
-select:valid {
+.valid {
   border: none;
   box-shadow: inset 0px 0px 10px var(--accent-blue);
 }
 
-input:invalid {
+.invalid {
   box-shadow: inset 0px 0px 10px var(--accent-red);
 }
 
 input[type="checkbox"] {
   box-shadow: none;
-  width: 20px;
-  height: 20px;
   cursor: pointer;
-  margin-right: 10px;
+  max-width: 20px;
+  height: 15px;
 }
 
 button {
@@ -135,6 +131,7 @@ button {
   height: 35px;
   border: none;
   background-color: var(--accent-blue);
+  color: var(--text-light);
   text-transform: uppercase;
   cursor: pointer;
   transition: background-color 0.5s ease-in-out;
@@ -147,6 +144,7 @@ button {
 
 .disabled {
   background-color: var(--blue-disabled);
+  color: var(--text-dark);
   cursor: not-allowed;
   pointer-events: none;
 }

--- a/src/pages/registration/checkValidityForm.ts
+++ b/src/pages/registration/checkValidityForm.ts
@@ -6,7 +6,7 @@ function isValidInput(inputValue: string, pattern: RegExp): boolean {
 
 function checkValidityAllFields() {
   const arrInputs = Array.from(document.querySelectorAll("input"));
-  return arrInputs.every((element) => isValidInput(element.value, new RegExp(element.pattern.replace('"', "/"))));
+  return arrInputs.every((element) => isValidInput(element.value, new RegExp(element.pattern)));
 }
 
 export function addValidationListenersToInput(
@@ -14,10 +14,9 @@ export function addValidationListenersToInput(
   text: string,
   nextElem: HTMLElement,
   parent: HTMLElement,
-  pattern?: string,
+  pattern?: RegExp,
 ) {
   if (!pattern) return;
-  const regExp = new RegExp(pattern.replace('"', "/"));
   inputTag.addEventListener("input", () => {
     const btnSubmit = document.querySelector(".submit-button");
     document.querySelector(`.error-${inputTag.name}`)?.remove();
@@ -26,11 +25,15 @@ export function addValidationListenersToInput(
     } else {
       btnSubmit?.classList.add("disabled");
     }
-    if (!isValidInput(inputTag.value, regExp)) {
-      const errorMessage = createEmptyDiv([`error-${inputTag.name}`, "error-message"], text);
-      parent.insertBefore(errorMessage, nextElem);
-    } else {
+    if (isValidInput(inputTag.value, pattern)) {
       document.querySelector(`.error-${inputTag.name}`)?.remove();
+      inputTag.classList.remove("invalid");
+      inputTag.classList.add("valid");
+    } else {
+      const errorMessage = createEmptyDiv([`error-${inputTag.name}`, "error-message"], text);
+      inputTag.classList.remove("valid");
+      inputTag.classList.add("invalid");
+      parent.insertBefore(errorMessage, nextElem);
     }
   });
   inputTag.addEventListener("invalid", (e: Event) => {

--- a/src/pages/registration/registration.css
+++ b/src/pages/registration/registration.css
@@ -10,19 +10,26 @@
 
 .addresses-wrapper {
   margin-top: 20px;
-  border-top: 1px solid var(--main-light);
   display: flex;
-  flex-direction: row;
-  gap: 30px;
-  margin-bottom: 20px;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.address-wrapper {
+  border-top: 1px solid var(--main-light);
 }
 
 .login-link-wrapper {
   margin-top: 20px;
 }
 
-.default-wrapper {
+.checkbox-wrapper {
   display: flex;
   flex-direction: row;
   align-items: center;
+  gap: 10px;
+}
+
+.registration-form button {
+  margin-top: 30px;
 }

--- a/src/pages/registration/registrationHandler.ts
+++ b/src/pages/registration/registrationHandler.ts
@@ -12,12 +12,16 @@ export function formRegistrationHandler(event: Event) {
   const name = <string>formData.get("name");
   const surname = <string>formData.get("surname");
   const birthday = <string>formData.get("birthday");
-  const city = <string>formData.get("city");
-  const streetName = <string>formData.get("street");
-  const postalCode = <string>formData.get("index");
-  const countries = <HTMLSelectElement>document.querySelector(".countries");
-  const country = countries.value;
-  const checkboxDefault = <HTMLInputElement>document.querySelector(".checkbox");
+  const checkboxSettingOneAddress = <HTMLInputElement>document.querySelector(".setting-one-address");
+  const countriesShipping = <HTMLSelectElement>document.querySelector(".countries-shipping");
+  const checkboxSettingDefaultAddressShipping = <HTMLInputElement>document.querySelector(".setting-default-address-shipping");
+
+  const addressShipping = {
+    city: <string>formData.get("city-shipping"),
+    streetName: <string>formData.get("street-shipping"),
+    postalCode: <string>formData.get("index-shipping"),
+    country: countriesShipping.value,
+  };
 
   const customer: Customer = {
     email: email.trim(),
@@ -25,12 +29,25 @@ export function formRegistrationHandler(event: Event) {
     firstName: name.trim(),
     lastName: surname.trim(),
     dateOfBirth: birthday,
-    addresses: [{ country, city, streetName, postalCode }],
+    addresses: [addressShipping],
     shippingAddresses: [0],
   };
-  if (checkboxDefault.checked) customer.defaultShippingAddress = 0;
-  // customer.billingAddresses = [0];
-  // customer.defaultBillingAddress = 0;
+
+  if (checkboxSettingDefaultAddressShipping.checked) customer.defaultShippingAddress = 0;
+
+  if (checkboxSettingOneAddress.checked) {
+    const countriesBilling = <HTMLSelectElement>document.querySelector(".countries-billing");
+    const addressBilling = {
+      city: <string>formData.get("city-billing"),
+      streetName: <string>formData.get("street-billing"),
+      postalCode: <string>formData.get("index-billing"),
+      country: countriesBilling.value,
+    };
+    const checkboxSettingDefaultAddressBilling = <HTMLInputElement>document.querySelector(".setting-default-address-billing");
+    if (checkboxSettingDefaultAddressBilling.checked) customer.defaultBillingAddress = 1;
+    customer.billingAddresses = [1];
+    customer.addresses.push(addressBilling);
+  }
 
   createCustomer(customer)
     .then((response) => {

--- a/src/pages/registration/registrationView.ts
+++ b/src/pages/registration/registrationView.ts
@@ -41,22 +41,20 @@ function createAccountWrapper(): HTMLElement {
   return accountWrapper;
 }
 
-function createAddressView(nameAddress: string, addressNotice: string): HTMLElement {
+function createAddressView(addressTitle: string, addressType: string): HTMLElement {
   const addressWrapper = createElement("div", ["address-wrapper"]);
-  const labelAddress = createEmptyDiv(["label"], nameAddress);
-  const country = createElement("select", [`countries-${addressNotice}`], "Страна");
+  const labelAddress = createEmptyDiv(["label"], addressTitle);
+  const country = createElement("select", [`countries-${addressType}`], "Страна");
   const optionBelarus = <HTMLOptionElement>createElement("option", ["option-country"], "Беларусь");
   optionBelarus.value = "BY";
   const optionRussia = <HTMLOptionElement>createElement("option", ["option-country"], "Россия");
   optionRussia.value = "RU";
   country.append(optionBelarus, optionRussia);
-  const city = createInput(`city-${addressNotice}`, "text", [`city-${addressNotice}`], "Город", cityPattern, cityTitle);
-  const street = createInput(`street-${addressNotice}`, "text", [`street-${addressNotice}`], "Улица", streetPattern, streetTitle);
-  const index = createInput(`index-${addressNotice}`, "text", [`index-${addressNotice}`], "Индекс", indexPattern, indexTitle);
+  const city = createInput(`city-${addressType}`, "text", [`city-${addressType}`], "Город", cityPattern, cityTitle);
+  const street = createInput(`street-${addressType}`, "text", [`street-${addressType}`], "Улица", streetPattern, streetTitle);
+  const index = createInput(`index-${addressType}`, "text", [`index-${addressType}`], "Индекс", indexPattern, indexTitle);
 
-  const checkboxSettingDefaultAddress = createInput(`setting-default-address-${addressNotice}`, "checkbox", [
-    `setting-default-address-${addressNotice}`,
-  ]);
+  const checkboxSettingDefaultAddress = createInput(`setting-default-address-${addressType}`, "checkbox", [`setting-default-address-${addressType}`]);
   const checkboxWrapper = createEmptyDiv(["checkbox-wrapper"]);
   const labelSettingDefaultAddress = createSpan(["label"], "Cделать адресом по умолчанию");
   checkboxSettingDefaultAddress.removeAttribute("required");

--- a/src/pages/registration/registrationView.ts
+++ b/src/pages/registration/registrationView.ts
@@ -4,14 +4,14 @@ import "../../index.css";
 import { formRegistrationHandler } from "./registrationHandler";
 import { addValidationListenersToInput } from "./checkValidityForm";
 
-export const emailPattern = "^[a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+.[a-zA-Z0-9_-]$";
-export const passwordPattern = "^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9]).{8,}";
-const namePattern = "[A-Za-zА-Яа-яё]{1,}$";
-const surnamePattern = "^[A-Za-zА-Яа-яё]{1,20}$";
-const birthdayPattern = "";
-const cityPattern = "^[A-Za-zА-Яа-яё]{1,15}$";
-const streetPattern = "[^s]{1,20}";
-const indexPattern = "[0-9]{6,6}";
+export const emailPattern: RegExp = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+export const passwordPattern: RegExp = /^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9]).{8,}/;
+const namePattern: RegExp = /^[A-Za-zА-Яа-яё]{1,}$/;
+const surnamePattern: RegExp = /^[A-Za-zА-Яа-яё]{1,20}$/;
+const birthdayPattern: RegExp = /[0-9]/;
+const cityPattern: RegExp = /^[A-Za-zА-Яа-яё]{1,15}$/;
+const streetPattern: RegExp = /^[^s]{1,20}$/;
+const indexPattern: RegExp = /^[0-9]{6,6}$/;
 
 export const emailTitle = "Email должен быть в формате example@example.ru";
 export const passwordTitle = "Пароль должен содержать не менее 8 символов и включать минимум 1 цифру, 1 заглавную и 1 строчную латинские буквы";
@@ -31,55 +31,76 @@ function createAccountWrapper(): HTMLElement {
   const labelBirthday = createEmptyDiv(["label"], "Дата рождения:");
   const birthday = createInput("birthday", "date", ["birthday"], "", birthdayPattern, birthdayTitle);
   birthday.max = "2011-01-01";
+  const blockForBirthdayError = createEmptyDiv(["wrapper"]);
   addValidationListenersToInput(email, emailTitle, password, accountWrapper, emailPattern);
   addValidationListenersToInput(password, passwordTitle, name, accountWrapper, passwordPattern);
   addValidationListenersToInput(name, nameTitle, surname, accountWrapper, namePattern);
   addValidationListenersToInput(surname, surnameTitle, labelBirthday, accountWrapper, surnamePattern);
-  addValidationListenersToInput(birthday, birthdayTitle, labelBirthday, accountWrapper, birthdayPattern);
-  accountWrapper.append(email, password, name, surname, labelBirthday, birthday);
+  addValidationListenersToInput(birthday, birthdayTitle, blockForBirthdayError, accountWrapper, birthdayPattern);
+  accountWrapper.append(email, password, name, surname, labelBirthday, birthday, blockForBirthdayError);
   return accountWrapper;
 }
 
-function createAddressWrapper(): HTMLElement {
+function createAddressView(nameAddress: string, addressNotice: string): HTMLElement {
   const addressWrapper = createElement("div", ["address-wrapper"]);
-  const labelAddress = createEmptyDiv(["label"], "Адрес доставки:");
-  const country = createElement("select", ["countries"], "Страна");
+  const labelAddress = createEmptyDiv(["label"], nameAddress);
+  const country = createElement("select", [`countries-${addressNotice}`], "Страна");
   const optionBelarus = <HTMLOptionElement>createElement("option", ["option-country"], "Беларусь");
   optionBelarus.value = "BY";
   const optionRussia = <HTMLOptionElement>createElement("option", ["option-country"], "Россия");
   optionRussia.value = "RU";
   country.append(optionBelarus, optionRussia);
-  const city = createInput("city", "text", ["city"], "Город", cityPattern, cityTitle);
-  const street = createInput("street", "text", ["street"], "Улица", streetPattern, streetTitle);
-  const index = createInput("index", "text", ["index"], "Индекс", indexPattern, indexTitle);
+  const city = createInput(`city-${addressNotice}`, "text", [`city-${addressNotice}`], "Город", cityPattern, cityTitle);
+  const street = createInput(`street-${addressNotice}`, "text", [`street-${addressNotice}`], "Улица", streetPattern, streetTitle);
+  const index = createInput(`index-${addressNotice}`, "text", [`index-${addressNotice}`], "Индекс", indexPattern, indexTitle);
 
-  const defaultAddressCheckbox = createInput("", "checkbox", ["checkbox"]);
-  const defaultWrapper = createEmptyDiv(["default-wrapper"]);
-  const labelDefault = createSpan(["label"], "Cделать адресом по умолчанию");
-  defaultAddressCheckbox.removeAttribute("required");
-  defaultWrapper.append(defaultAddressCheckbox, labelDefault);
+  const checkboxSettingDefaultAddress = createInput(`setting-default-address-${addressNotice}`, "checkbox", [
+    `setting-default-address-${addressNotice}`,
+  ]);
+  const checkboxWrapper = createEmptyDiv(["checkbox-wrapper"]);
+  const labelSettingDefaultAddress = createSpan(["label"], "Cделать адресом по умолчанию");
+  checkboxSettingDefaultAddress.removeAttribute("required");
+  checkboxWrapper.append(checkboxSettingDefaultAddress, labelSettingDefaultAddress);
 
   addValidationListenersToInput(city, cityTitle, street, addressWrapper, cityPattern);
   addValidationListenersToInput(street, streetTitle, index, addressWrapper, streetPattern);
-  addValidationListenersToInput(index, indexTitle, defaultWrapper, addressWrapper, indexPattern);
-  addValidationListenersToInput(defaultAddressCheckbox, "", defaultWrapper, addressWrapper);
-  addressWrapper.append(labelAddress, country, city, street, index, defaultWrapper);
+  addValidationListenersToInput(index, indexTitle, checkboxWrapper, addressWrapper, indexPattern);
+  addressWrapper.append(labelAddress, country, city, street, index, checkboxWrapper);
   return addressWrapper;
+}
+
+function switchAddingSecondAddress() {
+  const checkboxSettingOneAddress = <HTMLInputElement>document.querySelector(".setting-one-address");
+  if (checkboxSettingOneAddress.checked) {
+    const addressView = createAddressView("Адрес для счетов:", "billing");
+    document.querySelector(".addresses-wrapper")?.append(addressView);
+    document.querySelector(".submit-button")?.classList.add("disabled");
+  } else {
+    document.querySelectorAll(".address-wrapper")[1].remove();
+  }
 }
 
 export function renderRegistrationFormContent(): HTMLElement {
   const form = createElement("form", ["registration-form"]);
-  const h1 = createElement("h2", ["registration-form__heading"], "Заполните форму регистрации");
+  const h2 = createElement("h2", ["registration-form__heading"], "Заполните форму регистрации");
+  const h5 = createElement("h5", ["registration-form__info"], " * Все поля обязательны для заполнения");
   const accountWrapper = createAccountWrapper();
   const addressesWrapper = createElement("div", ["addresses-wrapper"]);
-  const address = createAddressWrapper();
-  addressesWrapper.append(address);
+  const address = createAddressView("Адрес для доставки:", "shipping");
+
+  const defaultWrapper = createEmptyDiv(["checkbox-wrapper"]);
+  const checkboxSettingOneAddress = createInput("setting-one-address", "checkbox", ["setting-one-address"]);
+  checkboxSettingOneAddress.addEventListener("change", switchAddingSecondAddress);
+  const labelDefault = createSpan(["label"], "Использовать разные адреса для доставки и счетов");
+  checkboxSettingOneAddress.removeAttribute("required");
+  defaultWrapper.append(checkboxSettingOneAddress, labelDefault);
+  addressesWrapper.append(address, defaultWrapper);
   const linkToLogin = createLink("#login", ["login-link"], "У вас уже есть аккаунт? Войти...");
   const regFormSubmitButton = createSubmitButton("Регистрация");
   form.addEventListener("submit", formRegistrationHandler);
   const loginLinkWrapper = createElement("div", ["login-link-wrapper"]);
   loginLinkWrapper.append(linkToLogin);
-  form.append(h1, accountWrapper, addressesWrapper, regFormSubmitButton, loginLinkWrapper);
+  form.append(h2, h5, accountWrapper, addressesWrapper, regFormSubmitButton, loginLinkWrapper);
   return form;
 }
 


### PR DESCRIPTION
1. Issue: https://github.com/nadyavalin/moon-store/issues/31
2. Task: https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint2/RSS-ECOMM-2_15.md
3. Screenshot:
![image](https://github.com/nadyavalin/moon-store/assets/60338444/d9ae5c7d-e6ae-46f4-a221-9a0920a9692f)
![image](https://github.com/nadyavalin/moon-store/assets/60338444/15d7a974-22d0-4b1b-8a85-9b43b563736b)

4. Branch feature/MS-31:

- [x] Users can enter separate addresses for billing and shipping during the registration process. 
- [x] Users can choose to use the same address for both billing and shipping. 
- [x] The chosen addresses are saved in the user profile upon successful registration. 
- [x] The user interface clearly distinguishes between input fields for billing and shipping addresses. 
- [x] Proper integration with the commercetools API for storing billing and shipping address information. 

- Fix pattern for email, change design input.
